### PR TITLE
feat: add OTLP stress testing infrastructure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = ["stress-test"]
+
 [package]
 name = "glust"
 version = "0.1.0"

--- a/stress-test/Cargo.toml
+++ b/stress-test/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "stress-test"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "generate-payload"
+path = "src/generate_payload.rs"
+
+[dependencies]
+opentelemetry-proto = { version = "0.28.0", features = ["gen-tonic-messages"] }
+prost = "0.13"

--- a/stress-test/STRESS_TEST.md
+++ b/stress-test/STRESS_TEST.md
@@ -1,0 +1,210 @@
+# Glust OTLP Stress Testing Guide
+
+This directory contains tools for stress testing the Glust OTLP log ingestion endpoint.
+
+## Overview
+
+The stress testing pipeline consists of:
+
+1. **Payload Generator** (`generate-payload`) - Creates a fixed OTLP protobuf payload
+2. **wrk Lua Script** (`wrk_otlp.lua`) - Loads the payload and executes HTTP stress tests
+3. **Runner Script** (`run_stress_test.sh`) - Orchestrates the test and collects metrics
+
+## Prerequisites
+
+### Required Tools
+
+- **Rust toolchain** - For building the payload generator
+- **wrk** - HTTP benchmarking tool ([github.com/wg/wrk](https://github.com/wg/wrk))
+
+### Installation
+
+```bash
+# Ubuntu/Debian
+sudo apt install wrk
+
+# macOS
+brew install wrk
+
+# Arch Linux
+sudo pacman -S wrk
+```
+
+## Quick Start
+
+```bash
+cd stress-test
+
+# Run with defaults (localhost:3000, 4 threads, 100 connections, 30s)
+./run_stress_test.sh
+
+# Custom configuration
+./run_stress_test.sh --host localhost --port 3000 --threads 8 --connections 200 --duration 60s
+```
+
+## Manual Execution
+
+### 1. Generate OTLP Payload
+
+```bash
+cargo build --release -p stress-test
+../target/release/generate-payload
+# Creates: payload.bin
+```
+
+### 2. Run wrk Directly
+
+```bash
+wrk -t4 -c100 -d30s -s wrk_otlp.lua http://localhost:3000/v1/logs
+```
+
+## Configuration Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `-t, --threads` | 4 | Number of wrk threads |
+| `-c, --connections` | 100 | Number of concurrent connections |
+| `-d, --duration` | 30s | Test duration |
+| `-h, --host` | localhost | Target host |
+| `-p, --port` | 3000 | Target port |
+| `-o, --output` | results.txt | Output file for results |
+
+## Metrics Collected
+
+### Throughput Metrics
+- **Requests/sec** - Number of requests completed per second
+- **Transfer/sec** - Data transfer rate
+
+### Latency Distribution
+- **Mean** - Average latency
+- **Stdev** - Standard deviation
+- **Max** - Maximum observed latency
+- **p50** - 50th percentile (median)
+- **p90** - 90th percentile
+- **p99** - 99th percentile
+- **p99.9** - 99.9th percentile
+
+### Error Tracking
+- Connect errors
+- Read errors
+- Write errors
+- Timeout errors
+- HTTP status errors (non-200)
+
+## Interpreting Results
+
+### Sample Output
+
+```
+========================================
+STRESS TEST RESULTS
+========================================
+
+Duration: 30.00 seconds
+Total Requests: 150000
+Total Errors: 0
+
+--- Throughput ---
+Requests/sec: 5000.00
+Transfer/sec: 512.00 KB
+
+--- Latency Distribution ---
+Mean:    2.50 ms
+Stdev:   1.20 ms
+Max:     45.00 ms
+p50:     2.00 ms
+p90:     4.00 ms
+p99:     8.00 ms
+p99.9:   15.00 ms
+```
+
+### Key Indicators
+
+| Metric | Good | Concerning |
+|--------|------|------------|
+| p99 latency | < 10ms | > 50ms |
+| Error rate | 0% | > 0.1% |
+| Throughput variance | < 10% | > 20% |
+
+## Test Scenarios
+
+### Baseline Test
+```bash
+./run_stress_test.sh -t2 -c50 -d30s
+```
+
+### High Concurrency
+```bash
+./run_stress_test.sh -t8 -c500 -d60s
+```
+
+### Sustained Load
+```bash
+./run_stress_test.sh -t4 -c100 -d300s
+```
+
+### Spike Test
+```bash
+# Run multiple tests with increasing load
+for c in 50 100 200 400 800; do
+    echo "Testing with $c connections..."
+    ./run_stress_test.sh -c$c -d10s -o "results_${c}.txt"
+    sleep 5
+done
+```
+
+## Results Documentation Template
+
+After running tests, document results in the following format:
+
+```markdown
+## Stress Test Results - [DATE]
+
+### Environment
+- Server: [specs]
+- Client: [specs]
+- Network: [local/remote]
+
+### Test Configuration
+- Duration: 30s
+- Threads: 4
+- Connections: 100
+
+### Results
+| Metric | Value |
+|--------|-------|
+| Requests/sec | X |
+| p50 | X ms |
+| p99 | X ms |
+| Error rate | X% |
+
+### Observations
+- [Notes about performance]
+- [Bottlenecks identified]
+- [Recommendations]
+```
+
+## Troubleshooting
+
+### "Server not reachable"
+Ensure the Glust server is running:
+```bash
+cargo run --release
+```
+
+### "payload.bin not found"
+Generate the payload first:
+```bash
+cargo build --release -p stress-test
+../target/release/generate-payload
+```
+
+### Low throughput
+- Check server resource utilization (CPU, memory)
+- Verify network isn't a bottleneck
+- Consider increasing server worker threads
+
+### High error rates
+- Check server logs for errors
+- Verify connection limits aren't being hit
+- Monitor for resource exhaustion

--- a/stress-test/run_stress_test.sh
+++ b/stress-test/run_stress_test.sh
@@ -1,0 +1,220 @@
+#!/bin/bash
+set -e
+
+# =============================================================================
+# Glust OTLP Stress Test Runner
+# =============================================================================
+# This script runs stress tests against the Glust OTLP ingestion endpoint
+# and collects throughput and latency metrics.
+#
+# Prerequisites:
+#   - wrk (https://github.com/wg/wrk)
+#   - Rust toolchain (for building payload generator)
+#   - Running Glust server on specified host:port
+#
+# Usage:
+#   ./run_stress_test.sh [OPTIONS]
+#
+# Options:
+#   -h, --host       Target host (default: localhost)
+#   -p, --port       Target port (default: 3000)
+#   -t, --threads    Number of threads (default: 4)
+#   -c, --connections Number of connections (default: 100)
+#   -d, --duration   Test duration (default: 30s)
+#   -o, --output     Output file for results (default: results.txt)
+# =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Default configuration
+HOST="localhost"
+PORT="3000"
+THREADS=4
+CONNECTIONS=100
+DURATION="30s"
+OUTPUT_FILE="results.txt"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+print_header() {
+    echo -e "${BLUE}========================================${NC}"
+    echo -e "${BLUE}$1${NC}"
+    echo -e "${BLUE}========================================${NC}"
+}
+
+print_success() {
+    echo -e "${GREEN}✓ $1${NC}"
+}
+
+print_warning() {
+    echo -e "${YELLOW}⚠ $1${NC}"
+}
+
+print_error() {
+    echo -e "${RED}✗ $1${NC}"
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--host)
+            HOST="$2"
+            shift 2
+            ;;
+        -p|--port)
+            PORT="$2"
+            shift 2
+            ;;
+        -t|--threads)
+            THREADS="$2"
+            shift 2
+            ;;
+        -c|--connections)
+            CONNECTIONS="$2"
+            shift 2
+            ;;
+        -d|--duration)
+            DURATION="$2"
+            shift 2
+            ;;
+        -o|--output)
+            OUTPUT_FILE="$2"
+            shift 2
+            ;;
+        --help)
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  -h, --host        Target host (default: localhost)"
+            echo "  -p, --port        Target port (default: 3000)"
+            echo "  -t, --threads     Number of threads (default: 4)"
+            echo "  -c, --connections Number of connections (default: 100)"
+            echo "  -d, --duration    Test duration (default: 30s)"
+            echo "  -o, --output      Output file for results (default: results.txt)"
+            exit 0
+            ;;
+        *)
+            print_error "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+TARGET_URL="http://${HOST}:${PORT}"
+
+print_header "Glust OTLP Stress Test"
+echo ""
+echo "Configuration:"
+echo "  Target:      ${TARGET_URL}/v1/logs"
+echo "  Threads:     ${THREADS}"
+echo "  Connections: ${CONNECTIONS}"
+echo "  Duration:    ${DURATION}"
+echo "  Output:      ${OUTPUT_FILE}"
+echo ""
+
+# Check dependencies
+print_header "Checking Dependencies"
+
+if ! command -v wrk &> /dev/null; then
+    print_error "wrk is not installed"
+    echo "Install with:"
+    echo "  Ubuntu/Debian: sudo apt install wrk"
+    echo "  macOS: brew install wrk"
+    exit 1
+fi
+print_success "wrk found"
+
+if ! command -v cargo &> /dev/null; then
+    print_error "Rust/Cargo is not installed"
+    exit 1
+fi
+print_success "cargo found"
+
+# Check if server is running
+echo ""
+print_header "Checking Server Availability"
+
+if curl -s --connect-timeout 5 "${TARGET_URL}" > /dev/null 2>&1 || curl -s --connect-timeout 5 "${TARGET_URL}/v1/logs" > /dev/null 2>&1; then
+    print_success "Server is reachable at ${TARGET_URL}"
+else
+    print_warning "Server may not be running at ${TARGET_URL}"
+    read -p "Continue anyway? (y/N) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
+fi
+
+# Generate OTLP payload
+echo ""
+print_header "Generating OTLP Payload"
+
+if [ ! -f "payload.bin" ]; then
+    echo "Building payload generator..."
+    cargo build --release -p stress-test --bin generate-payload
+
+    echo "Generating payload..."
+    ../target/release/generate-payload
+else
+    print_success "Using existing payload.bin"
+fi
+
+if [ ! -f "payload.bin" ]; then
+    print_error "Failed to generate payload.bin"
+    exit 1
+fi
+
+PAYLOAD_SIZE=$(stat -c%s "payload.bin" 2>/dev/null || stat -f%z "payload.bin" 2>/dev/null)
+print_success "Payload ready: ${PAYLOAD_SIZE} bytes"
+
+# Run stress test
+echo ""
+print_header "Running Stress Test"
+echo "Starting wrk with ${THREADS} threads, ${CONNECTIONS} connections for ${DURATION}..."
+echo ""
+
+# Capture system info
+TIMESTAMP=$(date -Iseconds)
+KERNEL=$(uname -r)
+CPU_INFO=$(grep "model name" /proc/cpuinfo 2>/dev/null | head -1 | cut -d: -f2 | xargs || sysctl -n machdep.cpu.brand_string 2>/dev/null || echo "Unknown")
+
+# Run wrk and capture output
+WRK_OUTPUT=$(wrk -t${THREADS} -c${CONNECTIONS} -d${DURATION} -s wrk_otlp.lua "${TARGET_URL}/v1/logs" 2>&1)
+
+echo "$WRK_OUTPUT"
+
+# Save results to file
+echo ""
+print_header "Saving Results"
+
+{
+    echo "# Glust OTLP Stress Test Results"
+    echo "# Generated: ${TIMESTAMP}"
+    echo ""
+    echo "## System Information"
+    echo "- Kernel: ${KERNEL}"
+    echo "- CPU: ${CPU_INFO}"
+    echo ""
+    echo "## Test Configuration"
+    echo "- Target: ${TARGET_URL}/v1/logs"
+    echo "- Threads: ${THREADS}"
+    echo "- Connections: ${CONNECTIONS}"
+    echo "- Duration: ${DURATION}"
+    echo "- Payload Size: ${PAYLOAD_SIZE} bytes"
+    echo ""
+    echo "## Raw Output"
+    echo '```'
+    echo "$WRK_OUTPUT"
+    echo '```'
+} > "$OUTPUT_FILE"
+
+print_success "Results saved to ${OUTPUT_FILE}"
+
+echo ""
+print_header "Test Complete"

--- a/stress-test/src/generate_payload.rs
+++ b/stress-test/src/generate_payload.rs
@@ -1,0 +1,97 @@
+use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
+use opentelemetry_proto::tonic::common::v1::{any_value, AnyValue, KeyValue};
+use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
+use opentelemetry_proto::tonic::resource::v1::Resource;
+use prost::Message;
+use std::fs::File;
+use std::io::Write;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn main() {
+    let payload = create_otlp_logs_payload();
+    let encoded = payload.encode_to_vec();
+
+    let mut file = File::create("payload.bin").expect("Failed to create payload file");
+    file.write_all(&encoded)
+        .expect("Failed to write payload to file");
+
+    println!("Generated OTLP payload: {} bytes", encoded.len());
+    println!("Saved to: payload.bin");
+}
+
+fn create_otlp_logs_payload() -> ExportLogsServiceRequest {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos() as u64;
+
+    let log_record = LogRecord {
+        time_unix_nano: now,
+        observed_time_unix_nano: now,
+        severity_number: 9, // INFO
+        severity_text: "INFO".to_string(),
+        body: Some(AnyValue {
+            value: Some(any_value::Value::StringValue(
+                "Stress test log message for OTLP ingestion benchmark".to_string(),
+            )),
+        }),
+        attributes: vec![
+            KeyValue {
+                key: "service.name".to_string(),
+                value: Some(AnyValue {
+                    value: Some(any_value::Value::StringValue("stress-test".to_string())),
+                }),
+            },
+            KeyValue {
+                key: "environment".to_string(),
+                value: Some(AnyValue {
+                    value: Some(any_value::Value::StringValue("benchmark".to_string())),
+                }),
+            },
+            KeyValue {
+                key: "request.id".to_string(),
+                value: Some(AnyValue {
+                    value: Some(any_value::Value::StringValue(
+                        "550e8400-e29b-41d4-a716-446655440000".to_string(),
+                    )),
+                }),
+            },
+        ],
+        dropped_attributes_count: 0,
+        flags: 0,
+        trace_id: vec![0u8; 16],
+        span_id: vec![0u8; 8],
+    };
+
+    let scope_logs = ScopeLogs {
+        scope: None,
+        log_records: vec![log_record],
+        schema_url: String::new(),
+    };
+
+    let resource_logs = ResourceLogs {
+        resource: Some(Resource {
+            attributes: vec![
+                KeyValue {
+                    key: "service.name".to_string(),
+                    value: Some(AnyValue {
+                        value: Some(any_value::Value::StringValue("glust-stress-test".to_string())),
+                    }),
+                },
+                KeyValue {
+                    key: "service.version".to_string(),
+                    value: Some(AnyValue {
+                        value: Some(any_value::Value::StringValue("1.0.0".to_string())),
+                    }),
+                },
+            ],
+            dropped_attributes_count: 0,
+        }),
+        scope_logs: vec![scope_logs],
+        schema_url: String::new(),
+    };
+
+    ExportLogsServiceRequest {
+        resource_logs: vec![resource_logs],
+    }
+}

--- a/stress-test/wrk_otlp.lua
+++ b/stress-test/wrk_otlp.lua
@@ -1,0 +1,63 @@
+-- wrk lua script for OTLP stress testing
+-- Usage: wrk -t4 -c100 -d30s -s wrk_otlp.lua http://localhost:3000/v1/logs
+
+local payload = nil
+
+function init(args)
+    local file = io.open("payload.bin", "rb")
+    if file then
+        payload = file:read("*all")
+        file:close()
+        print("Loaded OTLP payload: " .. #payload .. " bytes")
+    else
+        print("ERROR: Could not load payload.bin - run generate-payload first")
+        os.exit(1)
+    end
+end
+
+function request()
+    return wrk.format("POST", "/v1/logs", {
+        ["Content-Type"] = "application/x-protobuf"
+    }, payload)
+end
+
+function response(status, headers, body)
+    if status ~= 200 then
+        print("Error response: " .. status .. " - " .. body)
+    end
+end
+
+function done(summary, latency, requests)
+    print("\n========================================")
+    print("STRESS TEST RESULTS")
+    print("========================================")
+
+    local duration_s = summary.duration / 1000000
+    local requests_per_sec = summary.requests / duration_s
+    local bytes_per_sec = summary.bytes / duration_s
+
+    print(string.format("\nDuration: %.2f seconds", duration_s))
+    print(string.format("Total Requests: %d", summary.requests))
+    print(string.format("Total Errors: %d", summary.errors.status + summary.errors.connect + summary.errors.read + summary.errors.write + summary.errors.timeout))
+
+    print("\n--- Throughput ---")
+    print(string.format("Requests/sec: %.2f", requests_per_sec))
+    print(string.format("Transfer/sec: %.2f KB", bytes_per_sec / 1024))
+
+    print("\n--- Latency Distribution ---")
+    print(string.format("Mean:    %.2f ms", latency.mean / 1000))
+    print(string.format("Stdev:   %.2f ms", latency.stdev / 1000))
+    print(string.format("Max:     %.2f ms", latency.max / 1000))
+    print(string.format("p50:     %.2f ms", latency:percentile(50) / 1000))
+    print(string.format("p90:     %.2f ms", latency:percentile(90) / 1000))
+    print(string.format("p99:     %.2f ms", latency:percentile(99) / 1000))
+    print(string.format("p99.9:   %.2f ms", latency:percentile(99.9) / 1000))
+
+    print("\n--- Error Breakdown ---")
+    print(string.format("Connect errors: %d", summary.errors.connect))
+    print(string.format("Read errors:    %d", summary.errors.read))
+    print(string.format("Write errors:   %d", summary.errors.write))
+    print(string.format("Timeout errors: %d", summary.errors.timeout))
+    print(string.format("Status errors:  %d", summary.errors.status))
+    print("========================================\n")
+end


### PR DESCRIPTION
Add comprehensive stress testing pipeline for benchmarking the OTLP log ingestion endpoint. This enables measuring throughput and latency characteristics under various load conditions.

Components added:
- Rust payload generator for creating fixed OTLP protobuf payloads
- wrk lua script for HTTP load testing with detailed metrics
- Shell runner script with configurable parameters
- Documentation with usage guide and result interpretation

The pipeline measures key metrics including requests/sec, p50/p90/p99 latency percentiles, and error rates to establish performance baselines.